### PR TITLE
Influxdb 0.8.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN echo 'deb http://http.debian.net/debian wheezy-backports main' >> /etc/apt/s
        rpm build-essential git wget gawk \
     && curl -sSL https://get.docker.io/ | sh
 
-#checkout InfluxDB version 0.8.6
+#checkout InfluxDB version 0.8.8
 RUN mkdir -p $GOPATH/src/github.com/influxdb && \
  cd $GOPATH/src/github.com/influxdb && \
  git clone https://github.com/influxdb/influxdb.git && \
- cd influxdb && git checkout tags/v0.8.6
+ cd influxdb && git checkout tags/v0.8.8
 
 WORKDIR $GOPATH/src/github.com/influxdb/influxdb
 

--- a/config.toml
+++ b/config.toml
@@ -63,6 +63,9 @@ dir = "/data/influxdb/development/db"
 # will be replayed from the WAL
 write-buffer-size = 10000
 
+# The server will check this often for shards that have expired and should be cleared.
+retention-sweep-period = "10m"
+
 [cluster]
 # A comma separated list of servers to seed
 # this server. this is only relevant when the
@@ -114,7 +117,7 @@ lru-cache-size = "200m"
 
 # The default setting on this is 0, which means unlimited. Set this to something if you want to
 # limit the max number of open files. max-open-files is per shard so this * that will be max.
-max-open-shards = 0
+max-open-shards = 5
 
 # The default setting is 100. This option tells how many points will be fetched from LevelDb before
 # they get flushed into backend.

--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,7 @@ reporting-disabled = false
 
 [logging]
 # logging level can be one of "debug", "info", "warn" or "error"
-level  = "info"
+level  = "warn"
 file   = "/data/influxdb/influxdb.log"         # stdout to log to standard out
 
 # Configure the admin server

--- a/run_influxdb
+++ b/run_influxdb
@@ -2,9 +2,6 @@
 
 CONFIG_FILE="/etc/influxdb/config.toml"
 
-#Dynamically change the value of 'max-open-shards' to what 'ulimit -n' returns
-sed -i "s/^max-open-shards.*/max-open-shards = $(ulimit -n)/g" ${CONFIG_FILE}
-
 #Configure InfluxDB Cluster
 if [ -n "${HOSTNAME}" ]; then
 	if [ "${HOSTNAME}" == "auto" ]; then

--- a/run_influxdb
+++ b/run_influxdb
@@ -23,4 +23,4 @@ fi
 
 echo "=> Starting InfluxDB ..."
 
-exec /usr/bin/influxdb -config=/etc/influxdb/config.toml
+exec /usr/bin/influxdb -config=/etc/influxdb/config.toml -stdout


### PR DESCRIPTION
We had to update to influxdb 0.8.8 due to this issue:
https://github.com/influxdb/influxdb/issues/1181

Limit the max-open-shards to stop influxdb from growing to much in terms of memory.
