### PR TITLE
Raise max-open-shards to 1000

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -117,7 +117,7 @@ lru-cache-size = "200m"
 
 # The default setting on this is 0, which means unlimited. Set this to something if you want to
 # limit the max number of open files. max-open-files is per shard so this * that will be max.
-max-open-shards = 20
+max-open-shards = 1000
 
 # The default setting is 100. This option tells how many points will be fetched from LevelDb before
 # they get flushed into backend.


### PR DESCRIPTION
As we have found out while crawling through the [https://github.com/influxdb/influxdb] issues we found the following issues that suggest raising the number of open shards to avoid crashes on startup:
- influxdb/influxdb/issues/1123
- https://github.com/influxdb/influxdb/issues/280#issuecomment-36299333
